### PR TITLE
teach build.sh --clean work correctly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,12 @@ clean_gensrc() {
 
 clean_be() {
     pushd ${DORIS_HOME}
+
+    # "build.sh --clean" just cleans and exits, however CMAKE_BUILD_DIR is set
+    # while building be.
+    CMAKE_BUILD_TYPE=${BUILD_TYPE:-Release}
+    CMAKE_BUILD_DIR=${DORIS_HOME}/be/build_${CMAKE_BUILD_TYPE}
+
     rm -rf $CMAKE_BUILD_DIR
     rm -rf ${DORIS_HOME}/be/output/
     popd


### PR DESCRIPTION
CMAKE_BUILD_DIR is set while building be. "build.sh --clean" just
cleans and exits, however clean_be does not works without
CMAKE_BUILD_DIR set. This patch set CMAKE_BUILD_DIR in clean_be
to teach build.sh --clean work correctly.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
